### PR TITLE
making the secret wait time configurable

### DIFF
--- a/imapclient/views.py
+++ b/imapclient/views.py
@@ -50,8 +50,8 @@ def read_secrets():
         password=decrypted_password
     )
 
-def read_secret(secret_name):
-    attempts = 10
+def read_secret(secret_name):    
+    attempts = os.getenv('SECRET_READ_ATTEMPTS', 13)
     fullpath = os.path.join(settings.IMAPCLIENT_MOUNT_LOCATION, secret_name)
     while attempts > 0:
         try :


### PR DESCRIPTION
Due to kubernetes infrastructure issues, it takes approx 60 seconds to update a secret when exists.

That's why we keep getting the 'bad gateway' response.